### PR TITLE
nginx: prevent appending listen port on redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen       8080;
     server_name  localhost;
+    absolute_redirect off;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
closes #7

Tested on https://test-mvidalga.web.cern.ch/ and working as expected.