### PR TITLE
header: add google search box

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,4 +28,3 @@ rss = "index.xml" # Add this to show RSS button in social.
 platforms = ["github","twitter","email"]
 
 [params.sections_right]
-"/tags/" = "Tags"

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -58,10 +58,26 @@
         </a>
         {{- end -}}
         {{- end -}}
+        <form onsubmit="google_search(); return false;">
+          <input
+              type="text"
+              id="google-search"
+              placeholder="Search"
+          />
+        </form>
       </div>
       {{ end }}
       {{ end }}
     </nav>
   </div>
   <script src="/js/navicon-shift.js"></script>
+  <script type="text/javascript">
+    function google_search() {
+        const query = document.getElementById('google-search').value;
+        const domain = window.location.hostname;
+        window.open(
+          'https://www.google.com/search?q=' + query + '+site:' + domain
+        );
+    }
+  </script>
 </section>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -30,3 +30,16 @@ h1.title a,
     display: block;
     margin: auto;
 }
+
+#google-search {
+    margin-top: 10px;
+    padding: 10px;
+    border-radius: 10px;
+
+    border: 1px solid #eee;
+}
+
+#google-search:focus {
+    outline: none !important;
+    border: 1px solid #a9a9a9;
+}


### PR DESCRIPTION
- replace section_left in the left navigation with a search box
- when a user submits a search open a new tab with the google page

closes #25

The search box looks like this:

![Screenshot 2022-06-15 at 13 20 46](https://user-images.githubusercontent.com/15694232/173815493-8ce63e30-01e5-4928-a221-a4c14d99b89f.png)


How to test:

- run docker image in production mode; instructions are in README
- see how the search box feels, is it clear to find, etc.

