### PR TITLE
docs(chat): remove Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # blog.reana.io
 
-[![CI Actions Status](https://github.com/reanahub/blog.reana.io/workflows/CI/badge.svg)](https://github.com/reanahub/blog.reana.io/actions) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reanahub/reana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![License](https://img.shields.io/github/license/reanahub/blog.reana.io.svg)](https://github.com/reanahub/blog.reana.io/blob/master/LICENSE)
+[![image](https://github.com/reanahub/reana/workflows/CI/badge.svg)](https://github.com/reanahub/blog.reana.io/actions)
+[![image](https://img.shields.io/badge/discourse-forum-blue.svg)](https://forum.reana.io)
+[![image](https://img.shields.io/github/license/reanahub/blog.reana.io.svg)](https://github.com/reanahub/blog.reana.io/blob/master/LICENSE)
 
-## Clone
+## About
+
+REANA blog web site [blog.reana.io](https://blog.reana.io).
+
+## Developing
+
+Clone:
 
 ```console
 $ git clone git@github.com:reanahub/blog.reana.io.git
@@ -11,20 +19,20 @@ $ git submodule init
 $ git submodule update
 ```
 
-## Run locally
+Run locally:
 
 ```console
 $ hugo server -DF # shows drafts and future posts
 $ firefox http://localhost:1313
 ```
 
-## Create a new post
+Create a new post:
+
 ```console
 $ hugo new posts/2021/my-new-post.md
 ```
 
-## Run on Docker
-### Dev mode
+Run on Docker (in development mode):
 
 ```console
 $ docker build -t docker.io/reanahub/blog.reana.io --build-arg HUGO_CMD='-D' .
@@ -32,7 +40,7 @@ $ docker run --rm --name reanablog -p 8080:8080 docker.io/reanahub/blog.reana.io
 $ firefox http://localhost:8080
 ```
 
-### Production mode
+Run on Docker (in production mode):
 
 ```console
 $ docker build -t docker.io/reanahub/blog.reana.io --build-arg HUGO_CMD='--minify --gc' .
@@ -40,7 +48,7 @@ $ docker run --rm --name reanablog -p 8080:8080 docker.io/reanahub/blog.reana.io
 $ firefox http://localhost:8080
 ```
 
-## Openshift
+Run on OKD:
 
 ```console
 $ oc new-build https://github.com/reanahub/blog.reana.io --build-arg=HUGO_CMD='--minify --gc'


### PR DESCRIPTION
Remove the mention of Gitter for chat that we don't use since a few years. Keep recommending Forum and Mattermost as the two main communication channels.